### PR TITLE
Change Stencil baseUrl for Travis Deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - "10"
 
+before_script:
+  - sed -i "s/baseUrl: '\/'/baseUrl: 'stencil-tasklist\/'/" "${TRAVIS_BUILD_DIR}/stencil.config.ts"
+
 script:
   - npm run build
   - npm test

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -5,6 +5,7 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [{
     type: 'www',
+    baseUrl: '/',
     serviceWorker: null
   }],
   globalScript: 'src/global/app.ts',


### PR DESCRIPTION
Instruct Travis to replace the Stencil baseUrl so that GitHub Pages is happy.

The built index.html references assets from root, which doesn't work with GitHub pages.